### PR TITLE
Fix Python 3.13 compatibility by upgrading pydantic

### DIFF
--- a/services/requirements.base.txt
+++ b/services/requirements.base.txt
@@ -1,7 +1,7 @@
 # Base requirements shared across all services
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
-pydantic==2.5.0
+pydantic>=2.8.0
 httpx==0.25.2
 redis==5.0.1
 aioredis==2.0.1


### PR DESCRIPTION
## Problem
The project fails to install dependencies on Python 3.13 due to a compatibility issue with pydantic-core v2.14.1. The error occurs because older versions of pydantic-core don't support Python 3.13's updated `ForwardRef._evaluate()` method signature.

## Solution
- Upgrade pydantic from `2.5.0` to `>=2.8.0`
- This brings in pydantic-core 2.33.2 which is compatible with Python 3.13
- Resolves the `TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'` error

## Testing
- ✅ Successfully installs all dependencies on Python 3.13.7
- ✅ Uses compatible pydantic-core version (2.33.2)

This change maintains backward compatibility while enabling the project to work on Python 3.13.